### PR TITLE
Fix rendering of example markdown

### DIFF
--- a/packages/markdown-render-engine/src/renderers/Blockquote.tsx
+++ b/packages/markdown-render-engine/src/renderers/Blockquote.tsx
@@ -21,7 +21,7 @@ export const Blockquote: React.FunctionComponent<BlockquoteProps> = ({
       has(child, "props.children[0].props.children[0].props") &&
       child.props.children[0].props.children[0].props.value;
 
-    return type && type.replace(":", "").toLowerCase();
+    return (type && type.replace(":", "").toLowerCase()) || "";
   };
 
   const createPanels = (elem: any) => {
@@ -45,17 +45,25 @@ export const Blockquote: React.FunctionComponent<BlockquoteProps> = ({
   };
 
   let modifiedChildren = null;
+
   if (children && Array.isArray(children)) {
     modifiedChildren = children.reduce((accumulator: any, curr: any) => {
       const currType = getPanelType(curr);
+
       if (isOneOfTypes(currType)) {
         return [...accumulator, [curr]];
       }
 
       const len = accumulator.length - 1;
+
       if (len < 0 || !accumulator[len]) {
-        return children;
+        return [curr];
       }
+
+      if (!Array.isArray(accumulator[len])) {
+        return [[accumulator], curr];
+      }
+
       const newLastElement = [...accumulator[len], curr];
       return [...accumulator.slice(0, len), newLastElement];
     }, []);

--- a/packages/markdown-render-engine/src/renderers/Blockquote.tsx
+++ b/packages/markdown-render-engine/src/renderers/Blockquote.tsx
@@ -17,7 +17,7 @@ export const Blockquote: React.FunctionComponent<BlockquoteProps> = ({
   const isOneOfTypes = (arg?: string) => !!arg && panelTypes.includes(arg);
 
   const getPanelType = (child: any): string => {
-    const type =
+    const type: false | string =
       has(child, "props.children[0].props.children[0].props") &&
       child.props.children[0].props.children[0].props.value;
 

--- a/packages/markdown-render-engine/src/renderers/Blockquote.tsx
+++ b/packages/markdown-render-engine/src/renderers/Blockquote.tsx
@@ -57,7 +57,7 @@ export const Blockquote: React.FunctionComponent<BlockquoteProps> = ({
       const len = accumulator.length - 1;
 
       if (len < 0 || !accumulator[len]) {
-        return [curr];
+        return [[curr]];
       }
 
       if (!Array.isArray(accumulator[len])) {

--- a/packages/odata-react/src/tools/Parser.ts
+++ b/packages/odata-react/src/tools/Parser.ts
@@ -20,7 +20,7 @@ export const deepSearch = (
 
 class Parser {
   parseFromString(xmlString: string): any {
-    const outXmlString = transformer.transformToV4(xmlString);
+    const outXmlString = transformer.transformToV4(xmlString.trim());
 
     const rawObject = xml2js(outXmlString, {
       elementsKey: "children",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- make markdown-renderer not crash on example markdown from http://www.unexpected-vortices.com/sw/rippledoc/quick-markdown-example.html, as well as still working with markdown our docs, see https://github.com/kyma-project/kyma/issues/3982

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
