### PR TITLE
Bump vulnerable component versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1620,7 +1620,7 @@
     "@kyma-project/dc-async-api-render-engine": {
       "version": "file:packages/async-api-render-engine",
       "requires": {
-        "@asyncapi/react-component": "^0.17.10"
+        "@asyncapi/react-component": "^0.24.15"
       }
     },
     "@kyma-project/dc-markdown-render-engine": {
@@ -2210,7 +2210,7 @@
       "version": "file:packages/open-api-render-engine",
       "requires": {
         "js-yaml": "^3.13.1",
-        "swagger-ui-dist": "^3.22.3"
+        "swagger-ui-dist": "^4.1.3"
       },
       "dependencies": {
         "@types/js-yaml": {

--- a/packages/async-api-render-engine/package-lock.json
+++ b/packages/async-api-render-engine/package-lock.json
@@ -1,72 +1,87 @@
 {
   "name": "@kyma-project/dc-async-api-render-engine",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "@asyncapi/avro-schema-parser": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.2.0.tgz",
-      "integrity": "sha512-/oPDPudF82RGFXz5uhF77PSDZkAR+yHpdxUEbJ5jwk/X3RB74VRk8dqSgTqhUO+pLh+/Hut3x3VFacA8C9L2QA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-1.0.1.tgz",
+      "integrity": "sha512-j3JWLDkzWARlo2v/olOAgJ1aB9HNsvUUUHPKkx54ZNHUUbyVcDpQhBNSdvm8OBNKVa53QxLoDK7g59jhgUJZ9g==",
+      "requires": {
+        "avsc": "^5.7.3"
+      }
     },
     "@asyncapi/openapi-schema-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-2.0.0.tgz",
-      "integrity": "sha512-XfDp3EIs6ptar3jARQZzi3ObmS44l6Qozc5GJmZJUQ6mHLTTqUGJ0nxcrXAW88vosjilgJVaQ63oGolA6smSHQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-2.0.1.tgz",
+      "integrity": "sha512-algbtdM1gcAOa8+V8kp7WeBhdaNac82jmZUXx8YjyNfRVo02N2juDrjeBAGJd+FNva9Mb4MM7qfkJoAFpTL5VQ==",
       "requires": {
         "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.0"
       }
     },
     "@asyncapi/parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.3.0.tgz",
-      "integrity": "sha512-GwBRv/P/fwtkfKCU3FgDTpucdGuP73Zak2jsi2kOLvtwoBOgzyi45wHlxEJd2EikzaibIoWhO21P0rN9WVpFsw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.13.1.tgz",
+      "integrity": "sha512-Oaur97ZLf/2BpFK4566jpzivcj8sYSZTxfE33J186cE3Ac+Di4/tS7RCotYe4q60miNkzDRppDjE2KFmSxfTvw==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^2.7.5",
+        "@asyncapi/specs": "^2.11.0",
         "@fmvilas/pseudo-yaml-ast": "^0.3.1",
         "ajv": "^6.10.1",
         "js-yaml": "^3.13.1",
         "json-to-ast": "^2.1.0",
+        "lodash.clonedeep": "^4.5.0",
         "node-fetch": "^2.6.0",
         "tiny-merge-patch": "^0.1.2"
       }
     },
     "@asyncapi/react-component": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-0.17.10.tgz",
-      "integrity": "sha512-TylvSl/EzNhpVOa/PdDQT9CRu7t4oR1nkKPATfXUSbZRSJNMIxfehgfMG6uZmYmvCQh0waXHFVwUBF4p6hqlUw==",
+      "version": "0.24.19",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-0.24.19.tgz",
+      "integrity": "sha512-oORl8ZW87xLT8bDPeQRxMbIEkrE1CK6/5ZptrQebkOwEhku+lISh2uQMWtrvrDbJWPeS2qN83lCrSWaQq5hIJw==",
       "requires": {
-        "@asyncapi/avro-schema-parser": "^0.2.0",
-        "@asyncapi/openapi-schema-parser": "^2.0.0",
-        "@asyncapi/parser": "^1.2.0",
+        "@asyncapi/avro-schema-parser": "^1.0.0",
+        "@asyncapi/openapi-schema-parser": "^2.0.1",
+        "@asyncapi/parser": "^1.13.0",
         "constate": "^1.2.0",
         "dompurify": "^2.1.1",
         "markdown-it": "^11.0.1",
         "merge": "^2.1.0",
-        "openapi-sampler": "^1.0.0-beta.15",
+        "openapi-sampler": "1.0.0",
         "react-use": "^12.2.0"
       }
     },
     "@asyncapi/specs": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.5.tgz",
-      "integrity": "sha512-T1Ham9sqZKCtSowXRPaBCRy2oz3KHglqqrKiaO7lEudpP6lwH5SwXaq4qliyKzWaqd22srJHE4szdsorbFZKlw=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.12.0.tgz",
+      "integrity": "sha512-X4Xkrl+9WXSk5EJhsueIxNx6ymHI5wpkw4ofetV+VRnPLNob/XO4trPSJClrL5hlknxbGADLvlrkI5d3XJ996g=="
     },
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -85,34 +100,45 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@openapi-contrib/openapi-schema-to-json-schema": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.0.4.tgz",
-      "integrity": "sha512-+1RBoJ+xjX8mIXxisTJVlN/r6DOh4kyszw3cLBSAxwKP7Ui42DjlxWgR2PnWxOOWtRCnQurRzlsvL1ce5FUrWg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.1.1.tgz",
+      "integrity": "sha512-FMvdhv9Jr9tULjJAQaQzhCmNYYj2vQFVnl7CGlLAImZvJal71oedXMGszpPaZTLftAk5TCHqjnirig+P6LZxug==",
       "requires": {
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+    },
     "@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
-      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
       "requires": {
         "@types/prop-types": "*",
+        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "@types/react-wait": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react-wait/-/react-wait-0.3.1.tgz",
-      "integrity": "sha512-BS9AEjWZItDgpx6LlICcuf53M27zBFCsHx/llCbrmrt/WI7ecG2LGquCss3n8O8bwEDiTX4yYLjy8yLeIfgYTg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@types/react-wait/-/react-wait-0.3.2.tgz",
+      "integrity": "sha512-dKJp66yoIcexNBZNC0Mc8aFbRxi0rhvTehp5Cevi1V5s9G2C7Llwi/Fo/O3/g0gPaHsS4Je397wgs8PH4XcPuQ==",
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "ajv": {
       "version": "6.12.6",
@@ -126,17 +152,14 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+    "avsc": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
+      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A=="
     },
     "call-me-maybe": {
       "version": "1.0.1",
@@ -171,23 +194,23 @@
       }
     },
     "css-tree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.2.tgz",
-      "integrity": "sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "requires": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
       }
     },
     "csstype": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
     "dompurify": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
-      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz",
+      "integrity": "sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ=="
     },
     "entities": {
       "version": "2.0.3",
@@ -218,9 +241,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fastest-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-kSLUBtTJ2YvqZEpraFPVh0uHsCg="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "foreach": {
       "version": "2.0.5",
@@ -238,11 +261,10 @@
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "inline-style-prefixer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
-      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
+      "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
       "requires": {
-        "bowser": "^1.7.3",
         "css-in-js-utils": "^2.0.0"
       }
     },
@@ -258,6 +280,16 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        }
       }
     },
     "json-pointer": {
@@ -283,12 +315,17 @@
       }
     },
     "linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "requires": {
         "uc.micro": "^1.0.1"
       }
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "markdown-it": {
       "version": "11.0.1",
@@ -300,6 +337,16 @@
         "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        }
       }
     },
     "mdn-data": {
@@ -313,43 +360,40 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "merge": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.0.tgz",
-      "integrity": "sha512-TcuhVDV+e6X457MQAm7xIb19rWhZuEDEho7RrwxMpQ/3GhD5sDlnP188gjQQuweXHy9igdke5oUtVOXX1X8Sxg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w=="
     },
     "nano-css": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.0.tgz",
-      "integrity": "sha512-uM/9NGK9/E9/sTpbIZ/bQ9xOLOIHZwrrb/CRlbDHBU/GFS7Gshl24v/WJhwsVViWkpOXUmiZ66XO7fSB4Wd92Q==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.4.tgz",
+      "integrity": "sha512-wfcviJB6NOxDIDfr7RFn/GlaN7I/Bhe4d39ZRCJ3xvZX60LVe2qZ+rDqM49nm4YT81gAjzS+ZklhKP/Gnfnubg==",
       "requires": {
-        "css-tree": "^1.0.0-alpha.28",
-        "csstype": "^2.5.5",
-        "fastest-stable-stringify": "^1.0.1",
-        "inline-style-prefixer": "^4.0.0",
-        "rtl-css-js": "^1.9.0",
-        "sourcemap-codec": "^1.4.1",
-        "stacktrace-js": "^2.0.0",
-        "stylis": "3.5.0"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "2.6.14",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
-        }
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "openapi-sampler": {
-      "version": "1.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.18.tgz",
-      "integrity": "sha512-nG/0kvvSY5FbrU5A+Dbp1xTQN++7pKIh87/atryZlxrzDuok5Y6TCbpxO1jYqpUKLycE4ReKGHCywezngG6xtQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0.tgz",
+      "integrity": "sha512-HysKj4ZuLk0RpZkopao5SIupUX8LMOTsEDTw9dSzcRv6BBW6Ep1IdbKwYsCrYM9tnw4VZtebR/N5sJHY6qqRew==",
       "requires": {
-        "json-pointer": "^0.6.0"
+        "@types/json-schema": "^7.0.7",
+        "json-pointer": "^0.6.1"
       }
     },
     "punycode": {
@@ -386,9 +430,9 @@
       "integrity": "sha512-kB5x/kMKWcn0uVr9gBdNz21/oGbQwEQnF3P9p6E9yLfJ9DRcKS0fagbgYMFI0YFOoyKDj+2q6Rwax0kTYJF37g=="
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -396,17 +440,17 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "rtl-css-js": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.14.0.tgz",
-      "integrity": "sha512-Dl5xDTeN3e7scU1cWX8c9b6/Nqz3u/HgR4gePc1kWXYiQWVQbKCEyK6+Hxve9LbcJ5EieHy1J9nJCN3grTtGwg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
+      "integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
       "requires": {
         "@babel/runtime": "^7.1.2"
       }
     },
     "screenfull": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.1.0.tgz",
-      "integrity": "sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
     },
     "set-harmonic-interval": {
       "version": "1.0.1",
@@ -468,9 +512,9 @@
       }
     },
     "stylis": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
-      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "throttle-debounce": {
       "version": "2.3.0",
@@ -486,6 +530,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "ts-easing": {
       "version": "0.2.0",
@@ -503,11 +552,25 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "yaml-ast-parser": {

--- a/packages/async-api-render-engine/package.json
+++ b/packages/async-api-render-engine/package.json
@@ -26,7 +26,7 @@
     "render-engine"
   ],
   "dependencies": {
-    "@asyncapi/react-component": "^0.17.10"
+    "@asyncapi/react-component": "^0.24.15"
   },
   "peerDependencies": {
     "@kyma-project/documentation-component": "^0.3.0"

--- a/packages/documentation-component/package-lock.json
+++ b/packages/documentation-component/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyma-project/documentation-component",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/markdown-render-engine/package-lock.json
+++ b/packages/markdown-render-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyma-project/dc-markdown-render-engine",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/odata-react/package-lock.json
+++ b/packages/odata-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyma-project/odata-react",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/odata-render-engine/package-lock.json
+++ b/packages/odata-render-engine/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@kyma-project/dc-odata-render-engine",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "lockfileVersion": 1
 }

--- a/packages/open-api-render-engine/package-lock.json
+++ b/packages/open-api-render-engine/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyma-project/dc-open-api-render-engine",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -44,9 +44,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "swagger-ui-dist": {
-      "version": "3.23.10",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.23.10.tgz",
-      "integrity": "sha512-lK9oNNb9HAz2HJIg6+cYZszbYC/0CTm0nWi0XX2AjEbVgu43smbW2/h5zn7yAjYstPJBaYXkt5g6ABRpO/Ncfg=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.3.tgz",
+      "integrity": "sha512-WvfPSfAAMlE/sKS6YkW47nX/hA7StmhYnAHc6wWCXNL0oclwLj6UXv0hQCkLnDgvebi0MEV40SJJpVjKUgH1IQ=="
     }
   }
 }

--- a/packages/open-api-render-engine/package.json
+++ b/packages/open-api-render-engine/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "js-yaml": "^3.13.1",
-    "swagger-ui-dist": "^3.22.3"
+    "swagger-ui-dist": "^4.1.3"
   },
   "devDependencies": {
     "@types/js-yaml": "^3.12.1",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As mentioned in the linked issue, `merge` has identified vulnerability - CVE-2020-28499
Along with that, there are two more security issues:
- [WS-2021-0461](https://github.com/advisories/GHSA-qrmm-w75w-3wpx) in `swagger-ui-dist`
- CVE-2021-23820 in `json-pointer`

Both `merge` and `json-pointer` are dependencies of `@asyncapi/react-component`.

Changes proposed in this pull request:
- bump `swagger-ui-dist` to its latest version
- bump `@asyncapi/react-component` to its latest version

**Related issue(s)**
- https://github.com/kyma-incubator/documentation-component/issues/89
