### PR TITLE
Add Compass team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @m00g3n
+* @m00g3n @kyma-incubator/cmp_team
 
-*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @alexandra-simeonova @majakurcius @NHingerl
+*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @alexandra-simeonova @majakurcius @NHingerl @nkanchev


### PR DESCRIPTION
**Description**

As discussed with @kwiatekus and @valentinvieriu, I'm adding Compass team to CODEOWNERS, so we can also maintain the component, since it's used in [Compass Console](https://github.com/kyma-incubator/compass-console).

Changes proposed in this pull request:
- Add Compass team to CODEOWNERS
