### PR TITLE
Remove outdated CODEOWNERs from the list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 * @m00g3n @kyma-incubator/cmp_team
 
-*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj @alexandra-simeonova @majakurcius @NHingerl @nkanchev
+*.md @klaudiagrz @mmitoraj @alexandra-simeonova @majakurcius @NHingerl @grego952 @nkanchev


### PR DESCRIPTION
**Description**

As some of the CODEOWNERS on the list have left the Kyma organization a long time ago and are no longer active contributors, they must be removed from the list. The new Technical Writers should be added for the list to be complete.

Changes proposed in this pull request:

- Remove @kazydek , @tomekpapiernik, @bszwarc from the CODEOWNERS list.
- Add @grego952 as a documentation CODEOWNER.
